### PR TITLE
Add inventory option to configure skale-proxy ELB mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ pip install -r requirements.txt
 
    cert_mode=  # 'certbot' - generate using certbot / custom - upload your own
 
-   # Environment variable that determines if proxy is deployed behind AWS ELB.
+   # Environment variable that determines if proxy is deployed behind AWS ALB.
    # When set to true, configures Nginx to use X-Forwarded-For header for client IP.
-   # Set to true if deploying behind Elastic Load Balancer to ensure correct rate limiting.
+   # Set to true if deploying behind Application Load Balancer to ensure correct rate limiting.
    # Defaults to false for direct proxy deployments.
-   use_elb=
+   use_alb=
 
    do_token= # optional - DigitalOcean token (for 'certbot' cert_mode)
    email= # optional - SSL cert email (for 'certbot' cert_mode)

--- a/README.md
+++ b/README.md
@@ -21,43 +21,43 @@ pip install -r requirements.txt
 
 1. Create inventory for your network:
 
-```bash
-cp inventory-template inventory
-```
+   ```bash
+   cp inventory-template inventory
+   ```
 
 2. Configure inventory
 
-> If you need only proxy - remove `[explorer]` section.
+   > If you need only proxy - remove `[explorer]` section.
 
-```bash
-[proxy]
-proxy-0 ansible_host= ansible_ssh_user=
+   ```bash
+   [explorer]
+   explorer-0 ansible_host= ansible_ssh_user=
 
-[explorer]
-explorer-0 ansible_host= ansible_ssh_user=
+   [proxy]
+   proxy-0 ansible_host= ansible_ssh_user=
 
+   [all:vars]
+   ansible_ssh_user='' # username on machine(s) - e.g. ubuntu
+   ansible_python_interpreter=/usr/bin/python3
 
-[all:vars]
-ansible_ssh_user='' # username on machine(s) - e.g. ubuntu
-ansible_python_interpreter=/usr/bin/python3
+   base_path= # home path on the machine(s) - e.g. /home/ubuntu
+   proxy_domain='' # proxy domain name
+   explorer_domain='' # explorer domain name (optional for proxy-only setup)
+   eth_endpoint='' # Ethereum Mainnet endpoint
 
-base_path= # home path on the machine(s) - e.g. /home/ubuntu
-proxy_domain='' # proxy domain name
-explorer_domain='' # explorer domain name (optional for proxy-only setup)
-eth_endpoint='' # Ethereum Mainnet endpoint
+   cert_mode=  # 'certbot' - generate using certbot / custom - upload your own
 
-cert_mode=  # 'certbot' - generate using certbot / custom - upload your own
+   # Environment variable that determines if proxy is deployed behind AWS ELB.
+   # When set to true, configures Nginx to use X-Forwarded-For header for client IP.
+   # Set to true if deploying behind Elastic Load Balancer to ensure correct rate limiting.
+   # Defaults to false for direct proxy deployments.
+   use_elb=
 
-do_token= # optional - DigitalOcean token (for 'certbot' cert_mode)
-email= # optional - SSL cert email (for 'certbot' cert_mode)
+   do_token= # optional - DigitalOcean token (for 'certbot' cert_mode)
+   email= # optional - SSL cert email (for 'certbot' cert_mode)
 
-heartbeat_url= # optional - URL for heartbeat monitoring
-network_name= # optional - network name for dapp metrics
-
-mysql_user= # optional - MySQL user for metrics db
-mysql_password= # optional - MySQL password for metrics db
-mysql_root_password= # optional - MySQL root password for metrics db
-```
+   schain_names= # optional, run block explorer only for selected chains
+   ```
 
 3. Copy SKALE Manager ABI file for your network to `files/abi.json`
 4. Configure SSL.

--- a/inventory-template
+++ b/inventory-template
@@ -15,11 +15,11 @@ eth_endpoint='' # Ethereum Mainnet endpoint
 
 cert_mode=  # 'certbot' - generate using certbot / custom - upload your own
 
-# Environment variable that determines if proxy is deployed behind AWS ELB.
+# Environment variable that determines if proxy is deployed behind AWS ALB.
 # When set to true, configures Nginx to use X-Forwarded-For header for client IP.
-# Set to true if deploying behind Elastic Load Balancer to ensure correct rate limiting.
+# Set to true if deploying behind Application Load Balancer to ensure correct rate limiting.
 # Defaults to false for direct proxy deployments.
-use_elb=
+use_alb=
 
 do_token= # optional - DigitalOcean token (for 'certbot' cert_mode)
 email= # optional - SSL cert email (for 'certbot' cert_mode)

--- a/inventory-template
+++ b/inventory-template
@@ -15,6 +15,12 @@ eth_endpoint='' # Ethereum Mainnet endpoint
 
 cert_mode=  # 'certbot' - generate using certbot / custom - upload your own
 
+# Environment variable that determines if proxy is deployed behind AWS ELB.
+# When set to true, configures Nginx to use X-Forwarded-For header for client IP.
+# Set to true if deploying behind Elastic Load Balancer to ensure correct rate limiting.
+# Defaults to false for direct proxy deployments.
+use_elb=
+
 do_token= # optional - DigitalOcean token (for 'certbot' cert_mode)
 email= # optional - SSL cert email (for 'certbot' cert_mode)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-ansible==4.2.0
-skale.py==5.1dev5
+ansible==11.3.0
+skale.py==6.4b1
 boto3==1.17.34
-eth-account==0.5.3
 python-digitalocean==1.17.0

--- a/roles/proxy/tasks/main.yaml
+++ b/roles/proxy/tasks/main.yaml
@@ -33,5 +33,6 @@
     MYSQL_USER: "{{ mysql_user }}"
     MYSQL_PASSWORD: "{{ mysql_password }}"
     MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
+    USE_ELB: "{{ use_elb }}"
   args:
     chdir: "{{ base_path }}/skale-proxy"

--- a/roles/proxy/tasks/main.yaml
+++ b/roles/proxy/tasks/main.yaml
@@ -33,6 +33,6 @@
     MYSQL_USER: "{{ mysql_user }}"
     MYSQL_PASSWORD: "{{ mysql_password }}"
     MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
-    USE_ELB: "{{ use_elb }}"
+    USE_ALB: "{{ use_alb }}"
   args:
     chdir: "{{ base_path }}/skale-proxy"


### PR DESCRIPTION
## Overview

This pull request updates `proxy-provision` to support the new `USE_ELB` environment variable recently added to `skale-proxy`. This allows operators to configure the deployed proxy instance correctly depending on whether it runs behind an AWS Elastic Load Balancer (ELB) or is exposed directly.

## Problem

The `skale-proxy` service now requires the `USE_ELB` environment variable to be set to `true` when deployed behind an ELB (AWS Elastic Load Balancing) to ensure Nginx correctly identifies client IP addresses (via `X-Forwarded-For`) for rate limiting.
The `proxy-provision` repository previously lacked a way to set this variable based on the deployment environment.

## Solution

1.  **Inventory Variable:**
    * Added a new Ansible inventory variable `use_elb` (defaulting to `false`) to the `inventory-template`. This allows operators to specify per-deployment whether ELB mode should be enabled.

2.  **Ansible Task Update:**
    * Modified the Ansible task that runs `skale-proxy` (in `roles/proxy/tasks/main.yaml`) to read the `use_elb` inventory variable.
    * The task now passes the value of `use_elb` as the environment variable `USE_ELB` when starting the `skale-proxy` service (via Docker Compose).

3.  **Documentation:**
    * Updated `README.md` to document the new `use_elb` inventory variable and its purpose.

4.  Dependency Updates:**
    * Updated various project dependencies.

## Benefits

* Allows operators using `proxy-provision` to easily enable (`use_elb: true`) the ELB-specific Nginx configuration required by `skale-proxy`.
* Ensures correct client IP identification and rate limiting for `skale-proxy` instances deployed behind load balancers via this provisioning tooling.
* Integrates the configuration toggle cleanly into the existing Ansible inventory system.